### PR TITLE
Remove hard-coded API keys

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
-@"
 build/
 .dart_tool/
 android/app/build/
@@ -6,4 +5,4 @@ android/app/build/
 *.aab
 *.dill
 *.bin
-"@ > .gitignore
+lib/api_keys.dart

--- a/README.md
+++ b/README.md
@@ -1,1 +1,16 @@
 This is a codemagic test app
+
+## Configuration
+
+Copy `lib/api_keys.example.dart` to `lib/api_keys.dart` and set your secret keys or
+provide them via `--dart-define` when building the app. The following variables
+are required:
+
+* `GEMINI_API_KEY`
+* `IOS_GOOGLE_MAPS_API_KEY`
+* `ANDROID_GOOGLE_MAPS_API_KEY`
+* `WEB_GOOGLE_MAPS_API_KEY`
+* `FIREBASE_API_KEY`
+
+The `lib/api_keys.dart` file is listed in `.gitignore` so your keys remain
+private.

--- a/ios/Runner/AppDelegate.swift
+++ b/ios/Runner/AppDelegate.swift
@@ -9,7 +9,9 @@ import GoogleMaps
     _ application: UIApplication,
     didFinishLaunchingWithOptions launchOptions: [UIApplication.LaunchOptionsKey: Any]?
   ) -> Bool {
-    GMSServices.provideAPIKey("AIzaSyAhiNjvBpWvH1VVuoRGU5J3WnjVPFIzkE4")
+    if let apiKey = ProcessInfo.processInfo.environment["IOS_GOOGLE_MAPS_API_KEY"] ?? Bundle.main.object(forInfoDictionaryKey: "IOS_GOOGLE_MAPS_API_KEY") as? String {
+      GMSServices.provideAPIKey(apiKey)
+    }
     GeneratedPluginRegistrant.register(with: self)
     return super.application(application, didFinishLaunchingWithOptions: launchOptions)
   }

--- a/ios/Runner/Info.plist
+++ b/ios/Runner/Info.plist
@@ -25,6 +25,8 @@
     <string>$(FLUTTER_BUILD_NAME)</string>
     <key>CFBundleSignature</key>
     <string>????</string>
+    <key>IOS_GOOGLE_MAPS_API_KEY</key>
+    <string>YOUR_IOS_GOOGLE_MAPS_API_KEY</string>
     <key>CFBundleURLTypes</key>
     <array>
       <dict>

--- a/lib/api_keys.example.dart
+++ b/lib/api_keys.example.dart
@@ -1,0 +1,7 @@
+class ApiKeys {
+  static const String geminiApiKey = String.fromEnvironment('GEMINI_API_KEY');
+  static const String iosGoogleMapsApiKey = String.fromEnvironment('IOS_GOOGLE_MAPS_API_KEY');
+  static const String androidGoogleMapsApiKey = String.fromEnvironment('ANDROID_GOOGLE_MAPS_API_KEY');
+  static const String webGoogleMapsApiKey = String.fromEnvironment('WEB_GOOGLE_MAPS_API_KEY');
+  static const String firebaseApiKey = String.fromEnvironment('FIREBASE_API_KEY');
+}

--- a/lib/backend/firebase/firebase_config.dart
+++ b/lib/backend/firebase/firebase_config.dart
@@ -1,11 +1,12 @@
 import 'package:firebase_core/firebase_core.dart';
 import 'package:flutter/foundation.dart';
+import '../api_keys.dart';
 
 Future initFirebase() async {
   if (kIsWeb) {
     await Firebase.initializeApp(
         options: FirebaseOptions(
-            apiKey: "AIzaSyDda3SdKa-AQaqscTdDUdWpc0LifQRMamg",
+            apiKey: ApiKeys.firebaseApiKey,
             authDomain: "gym-feed-official-27tdk3.firebaseapp.com",
             projectId: "gym-feed-official-27tdk3",
             storageBucket: "gym-feed-official-27tdk3.appspot.com",

--- a/lib/backend/gemini/gemini.dart
+++ b/lib/backend/gemini/gemini.dart
@@ -2,15 +2,14 @@ import 'package:flutter/material.dart';
 import 'package:google_generative_ai/google_generative_ai.dart';
 import 'package:http/http.dart' as http;
 import '/flutter_flow/flutter_flow_util.dart';
-
-const _kGeminiApiKey = 'AIzaSyA0H35X91AHIMogtbO3zB_FRkJFgylufFc';
+import '../api_keys.dart';
 
 Future<String?> geminiGenerateText(
   BuildContext context,
   String prompt,
 ) async {
   final model =
-      GenerativeModel(model: 'gemini-1.5-pro', apiKey: _kGeminiApiKey);
+      GenerativeModel(model: 'gemini-1.5-pro', apiKey: ApiKeys.geminiApiKey);
   final content = [Content.text(prompt)];
 
   try {
@@ -30,7 +29,7 @@ Future<String?> geminiCountTokens(
   String prompt,
 ) async {
   final model =
-      GenerativeModel(model: 'gemini-1.5-pro', apiKey: _kGeminiApiKey);
+      GenerativeModel(model: 'gemini-1.5-pro', apiKey: ApiKeys.geminiApiKey);
   final content = [Content.text(prompt)];
 
   try {
@@ -67,7 +66,7 @@ Future<String?> geminiTextFromImage(
   );
 
   final model =
-      GenerativeModel(model: 'gemini-1.5-flash', apiKey: _kGeminiApiKey);
+      GenerativeModel(model: 'gemini-1.5-flash', apiKey: ApiKeys.geminiApiKey);
   final imageBytes = uploadImageBytes != null
       ? uploadImageBytes.bytes
       : await loadImageBytesFromUrl(imageNetworkUrl!);

--- a/lib/pages/posts/edit_post/edit_post_widget.dart
+++ b/lib/pages/posts/edit_post/edit_post_widget.dart
@@ -5,6 +5,7 @@ import '/flutter_flow/flutter_flow_theme.dart';
 import '/flutter_flow/flutter_flow_util.dart';
 import '/flutter_flow/flutter_flow_widgets.dart';
 import '/index.dart';
+import '../../../api_keys.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:provider/provider.dart';
@@ -434,11 +435,11 @@ class _EditPostWidgetState extends State<EditPostWidget> {
                   padding: EdgeInsetsDirectional.fromSTEB(15.0, 0.0, 0.0, 0.0),
                   child: FlutterFlowPlacePicker(
                     iOSGoogleMapsApiKey:
-                        'AIzaSyAhiNjvBpWvH1VVuoRGU5J3WnjVPFIzkE4',
+                        ApiKeys.iosGoogleMapsApiKey,
                     androidGoogleMapsApiKey:
-                        'AIzaSyD60h9pruOAaVuyPzjCD5Cg3fxemawEUpg',
+                        ApiKeys.androidGoogleMapsApiKey,
                     webGoogleMapsApiKey:
-                        'AIzaSyBaAKbRwjQpBxUxfa46HZYGwxPTwpXqy4g',
+                        ApiKeys.webGoogleMapsApiKey,
                     onSelect: (place) async {
                       safeSetState(() => _model.placePickerValue = place);
                     },

--- a/lib/pages/posts/new_post/new_post_widget.dart
+++ b/lib/pages/posts/new_post/new_post_widget.dart
@@ -15,6 +15,7 @@ import 'dart:async';
 import '/custom_code/actions/index.dart' as actions;
 import '/flutter_flow/custom_functions.dart' as functions;
 import '/index.dart';
+import '../../../api_keys.dart';
 import 'package:flutter/material.dart';
 import 'package:flutter/scheduler.dart';
 import 'package:flutter_animate/flutter_animate.dart';
@@ -745,11 +746,11 @@ class _NewPostWidgetState extends State<NewPostWidget>
                                                     child:
                                                         FlutterFlowPlacePicker(
                                                       iOSGoogleMapsApiKey:
-                                                          'AIzaSyAhiNjvBpWvH1VVuoRGU5J3WnjVPFIzkE4',
+                                                          ApiKeys.iosGoogleMapsApiKey,
                                                       androidGoogleMapsApiKey:
-                                                          'AIzaSyD60h9pruOAaVuyPzjCD5Cg3fxemawEUpg',
+                                                          ApiKeys.androidGoogleMapsApiKey,
                                                       webGoogleMapsApiKey:
-                                                          'AIzaSyBaAKbRwjQpBxUxfa46HZYGwxPTwpXqy4g',
+                                                          ApiKeys.webGoogleMapsApiKey,
                                                       onSelect: (place) async {
                                                         safeSetState(() => _model
                                                                 .placePickerValue =

--- a/lib/workout/edit_training/edit_training_widget.dart
+++ b/lib/workout/edit_training/edit_training_widget.dart
@@ -11,6 +11,7 @@ import '/flutter_flow/form_field_controller.dart';
 import '/flutter_flow/upload_data.dart';
 import '/custom_code/actions/index.dart' as actions;
 import '/index.dart';
+import '../../api_keys.dart';
 import 'package:easy_debounce/easy_debounce.dart';
 import 'package:flutter/material.dart';
 import 'edit_training_model.dart';
@@ -1165,11 +1166,11 @@ class _EditTrainingWidgetState extends State<EditTrainingWidget>
                                                             children: [
                                                               FlutterFlowPlacePicker(
                                                                 iOSGoogleMapsApiKey:
-                                                                    'AIzaSyAhiNjvBpWvH1VVuoRGU5J3WnjVPFIzkE4',
+                                                                    ApiKeys.iosGoogleMapsApiKey,
                                                                 androidGoogleMapsApiKey:
-                                                                    'AIzaSyD60h9pruOAaVuyPzjCD5Cg3fxemawEUpg',
+                                                                    ApiKeys.androidGoogleMapsApiKey,
                                                                 webGoogleMapsApiKey:
-                                                                    'AIzaSyBaAKbRwjQpBxUxfa46HZYGwxPTwpXqy4g',
+                                                                    ApiKeys.webGoogleMapsApiKey,
                                                                 onSelect:
                                                                     (place) async {
                                                                   safeSetState(() =>

--- a/lib/workout/schedule_training/schedule_training_widget.dart
+++ b/lib/workout/schedule_training/schedule_training_widget.dart
@@ -18,6 +18,7 @@ import 'package:firebase_storage/firebase_storage.dart';
 import 'package:flutter/material.dart';
 import 'package:google_fonts/google_fonts.dart';
 import 'schedule_training_model.dart';
+import '../../api_keys.dart';
 export 'schedule_training_model.dart';
 
 class ScheduleTrainingWidget extends StatefulWidget {
@@ -411,11 +412,11 @@ class _ScheduleTrainingWidgetState extends State<ScheduleTrainingWidget>
                                                         children: [
                                                           FlutterFlowPlacePicker(
                                                             iOSGoogleMapsApiKey:
-                                                                'AIzaSyAhiNjvBpWvH1VVuoRGU5J3WnjVPFIzkE4',
+                                                                ApiKeys.iosGoogleMapsApiKey,
                                                             androidGoogleMapsApiKey:
-                                                                'AIzaSyD60h9pruOAaVuyPzjCD5Cg3fxemawEUpg',
+                                                                ApiKeys.androidGoogleMapsApiKey,
                                                             webGoogleMapsApiKey:
-                                                                'AIzaSyBaAKbRwjQpBxUxfa46HZYGwxPTwpXqy4g',
+                                                                ApiKeys.webGoogleMapsApiKey,
                                                             onSelect:
                                                                 (place) async {
                                                               safeSetState(() =>

--- a/web/index.html
+++ b/web/index.html
@@ -53,7 +53,7 @@
 </head>
 <body>
   
-  <script src="https://maps.googleapis.com/maps/api/js?key=AIzaSyBaAKbRwjQpBxUxfa46HZYGwxPTwpXqy4g"></script>
+  <script src="https://maps.googleapis.com/maps/api/js?key=%WEB_GOOGLE_MAPS_API_KEY%"></script>
   
   
   


### PR DESCRIPTION
## Summary
- read API keys from a new `ApiKeys` helper
- update Google Maps credentials to use environment variables
- load Firebase web API key from environment
- add examples and ignore real `api_keys.dart`
- document required variables in README

## Testing
- `flutter --version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_6847d2ad62dc832cb9e25c42c73d9a25